### PR TITLE
Add RTP output

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Usage: mtx [<options>]
     -h <addr>   IP address (default: 239.48.48.1)
     -p <port>   UDP port (default: 1350)
     -d <dev>    ALSA device name, or '-' for stdin (default: 'default')
+    -R <n>      RTP output (default: 0)
     -f <n>      Use float samples (1) or signed 16 bit integer samples (0) (default: 0)
     -r <rate>   Audio sample rate (default: 48000 Hz)
     -c <n>      Audio channel count (default: 2)
@@ -69,6 +70,17 @@ pcm.pnm {
 - If having problems try **`sudo ./mrx -d pulse`**
 - On OpenWrt and/or with cheap USB audio cards without PulseAudio, if it doesn't work try **`mrx -d plughw:0,0`**
 - It shouldn't be needed anymore, but it might still be useful, so [this is a working `/etc/asound.conf` file for OpenWrt with cheap USB audio cards](https://gist.github.com/VittGam/ad0c1ce0143e4fb7a55fe8947b085e26)
+
+### RTP
+
+RTP output is useful for transmitting to other applications, e.g. FFmpeg.
+You don't need any PulseAudio integration; just run mtx with -R 1 and
+-d etc. as usual. This will output an SDP file, which you can run in e.g.
+ffplay with
+
+```
+ffplay -protocol_whitelist rtp,file,udp -i mtx.sdp
+```
 
 ## Bugs
 

--- a/mtrx.h
+++ b/mtrx.h
@@ -41,6 +41,15 @@ struct __attribute__((__packed__)) azzp {
 	unsigned char data;
 };
 
+struct __attribute__((__packed__)) rtp {
+	uint8_t version_p_x_cc;
+	uint8_t marker_and_pt;
+	uint16_t seq;
+	uint32_t timestamp;
+	uint32_t ssrc;
+	unsigned char data;
+};
+
 struct __attribute__((__packed__)) timep {
 	int64_t tv_sec;
 	uint32_t tv_nsec;

--- a/mtx.c
+++ b/mtx.c
@@ -57,7 +57,7 @@ int main(int argc, char *argv[]) {
 	fprintf(stderr, "Copyright (C) 2014-2017 Vittorio Gambaletta <openwrt@vittgam.net>\n\n");
 
 	while (1) {
-		int c = getopt(argc, argv, "h:p:d:f:r:c:t:k:b:v:");
+		int c = getopt(argc, argv, "h:p:d:f:r:c:t:k:b:v:T:");
 		if (c == -1) {
 			break;
 		} else if (c == 'h') {


### PR DESCRIPTION
Hi,

I wanted to use mtrx to use some remote microphones over IP, but I already have FFmpeg input support and didn't want to involve dmix etc., so I thought it would be useful to have RTP output, which FFmpeg can consume directly. It's simple enough, so I'm sending it back as a PR.